### PR TITLE
Try to use manifest.xml instead as in radio

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -607,7 +607,7 @@
                "ShortDescriptionLine2":"See http://www.iba.org.il/arabil",
                "Poster":"iba33.png",
                "StreamUrls":[
-                  "http://iba-s.vidnt.com/iba_channel-33MRepeat/_definst_/smil:channel-33M.smil/chunklist_w1566304997_b1392000.m3u8"
+                  "http://iba-metadata-rr-d.vidnt.com/live/iba/channel-33M/hls/metadata.xml?smil_profile=default"
                ],
                "StreamFormat":"hls",
                "Live":true


### PR DESCRIPTION
IBA Radio uses retrival of XML from CDN
to btain specific URL and parameters at runtime
This XML is available for IBA's radio and TV streams
for some reason not required cfor Arutz1 but will switch
soon to this to avoid surprises.