### PR TITLE
Add codes for external-control launch for old apps

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -367,6 +367,7 @@
          "Default":true,
          "Items":[
             {
+               "ecpCode":"ch1",
                "Title":"Israel Brodcast Authority - Arutz 1",
                "ShortDescriptionLine1":"Arutz 1",
                "ShortDescriptionLine2":"See http://www.iba.org.il",
@@ -390,6 +391,7 @@
                "Live":true
             },
             {
+               "ecpCode":"ch2news",
                "Title":"Israel channel 2 News",
                "ShortDescriptionLine1":"Hadashot Arutz 2",
                "ShortDescriptionLine2":"See http://www.mako.co.il/news & http://reshet.tv/News_n/heb/news",
@@ -402,6 +404,7 @@
                "Live":true
             },
             {
+               "ecpCode":"ch10",
                "Title":"Israel channel 10",
                "ShortDescriptionLine1":"Arutz 10",
                "ShortDescriptionLine2":"See http://www.nana10.co.il",
@@ -413,6 +416,7 @@
                "Live":true
             },
             {
+               "ecpCode":"ch20",
                "Title":"Israel channel 20",
                "ShortDescriptionLine1":"Arutz 20",
                "ShortDescriptionLine2":"See www.ch-20.tv",
@@ -580,6 +584,7 @@
          "Name":"Other Languages",
          "Items":[
             {
+               "ecpCode":"i24en",
                "Title":"i24 English",
                "ShortDescriptionLine1":"i24 news and current affairs channel (English)",
                "ShortDescriptionLine2":"See Beyond http://www.i24news.tv/en",


### PR DESCRIPTION
Want to start retiring 5 legacy apps, to that end would like to replace those
with small "bookmark" apps that will install and launch IsraTV, jumping into
the specific channel.  Feature not yet implemented - this just enables future impl.