### PR TITLE
Hotfixing a bypass to the vimmi method

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -448,6 +448,9 @@
                "ShortDescriptionLine2":"See http://www.sport5.co.il",
                "Poster":"sport5.png",
                "StreamUrls":[
+                  "http://sport5_live1-lh.akamaihd.net/i/live3_0@129322/index_3_av-p.m3u8",
+                  "http://sport5_live1-lh.akamaihd.net/i/live3_0@129322/index_2_av-p.m3u8",
+                  "http://sport5_live1-lh.akamaihd.net/i/live3_0@129322/index_1_av-p.m3u8",
                   "http://rr-d.vidnt.com/live/s5site/LiveIsrael/hls/metadata.xml?smil_profile=default"
                ],
                "StreamFormat":"hls",


### PR DESCRIPTION
-not tested - hotfix from the road
Will debug later if sport5 no longer streaming via vimmi but for now using the direct HLS links