### PR TITLE
Updates for the week ending September 9, 2016 

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -722,7 +722,7 @@
                      "On the road - Golan Heights with Itai Vered"
                   ],
                   "928098":[
-                     "Tsfonim bakotev",
+                     "Tsfonim bakotev - Note: GeoBlocked",
                      "Northerners in the pole - documentary about Norwegian explorer"
                   ],
                   "636639":[
@@ -905,7 +905,7 @@
                   ],
                   "7120937":[
                      "Cosmos",
-                     "Cosmos"
+                     "Note: GeoBlocked"
                   ],
                   "7120844":[
                      "Ha'efech",
@@ -941,7 +941,7 @@
                   ],
                   "7120563":[
                      "Shoa hachazit amizrachit",
-                     "Shoa eastern front"
+                     "Shoa eastern front - Note: GeoBlocked"
                   ],
                   "7120363":[
                      "Yitzhak Rabin",
@@ -1065,7 +1065,7 @@
                   ],
                   "7119408":[
                      "Capitalism",
-                     ""
+                     "Note: Some or all episodes are GeoBlocked"
                   ],
                   "7119670":[
                      "hasipur ha'amiti - haherzelim",
@@ -1117,11 +1117,11 @@
                   ],
                   "7065744":[
                      "Exodus - 47",
-                     ""
+                     "Note: GeoBlocked"
                   ],
                   "7093443":[
                      "Exodues from Egypt",
-                     ""
+                     "Note: GeoBlocked"
                   ],
                   "7092552":[
                      "hayeled kvar lo cholem",
@@ -1468,7 +1468,7 @@
                      "Every mother should know - The 1982 Lebanon war documentary"
                   ],
                   "7121336":[
-                     "Schitut",
+                     "Schitut - Note: GeoBlocked",
                      "A British series on a special police anti-corruption unit"
                   ],
                   "7120470":[
@@ -1694,6 +1694,106 @@
                   "7120039":[
                      "chagot tishrei",
                      "Women's perspectives of the High Holidays's"
+                  ],
+                  "7064349":[
+                     "choma shel tikva",
+                     "Israeli athletes in the 2008 Beijing Paralympic Games"
+                  ],
+                  "7119986":[
+                     "mikdash me'at",
+                     "Documentary series on the role of synagogues in Israel"
+                  ],
+                  "7119462":[
+                     "yom shel tzom",
+                     "Fasting in Jewish tradition"
+                  ],
+                  "7093541":[
+                     "yom yerushalaim",
+                     "Jerusalem Day National Commemoration "
+                  ],
+                  "7067787":[
+                     "tekes chaylim mitztainim",
+                     "Ceremony for honored soldiers at the President residence"
+                  ],
+                  "7119646":[
+                     "eduyot",
+                     "Meetings between Holocaust survivors and the third generation"
+                  ],
+                  "7119411":[
+                     "purim charedi",
+                     "Purim in the Jerusalem Haredi community"
+                  ],
+                  "7119385":[
+                     "atzeret zikaron le'yom hashoa",
+                     "Commemoration of the International Shoah Day in Auschwitz"
+                  ],
+                  "7119239":[
+                     "yemei hachanoka",
+                     "Video clips on Chanukah"
+                  ],
+                  "7119241":[
+                     "li'r'otam bilvad",
+                     "A program about Chanukah symbols"
+                  ],
+                  "7119091":[
+                     "eifo rachel imeino",
+                     "The story of Rachel's Tomb"
+                  ],
+                  "7118983":[
+                     "Simcha ve'tora",
+                     "A program for Simchat Torah 2016"
+                  ],
+                  "7092394":[
+                     "chagei tishre with Sasha Demidov",
+                     "Sasha Demidov's special program on the High Holidays"
+                  ],
+                  "7092388":[
+                     "eifo atem bachag",
+                     "A program about the holidays and Simchat Torah"
+                  ],
+                  "7118982":[
+                     "Ba'it",
+                     "Special program for Sukkot"
+                  ],
+                  "7116678":[
+                     "margishim chag",
+                     "Yom Kippur"
+                  ],
+                  "7118979":[
+                     "slicha",
+                     "Special program for Yom Kippur"
+                  ],
+                  "7092385":[
+                     "shanot tovot",
+                     "Special program for Rosh Hashanah"
+                  ],
+                  "7118978":[
+                     "shmita",
+                     "Special program for Rosh Hashanah focusing on the coming year"
+                  ],
+                  "7118708":[
+                     "shir shechalamti",
+                     "Czech Jewish history"
+                  ],
+                  "7061081":[
+                     "leil shavuot",
+                     "Special program for Shavuot"
+                  ],
+                  "7058480":[
+                     "chozer im tshuva",
+                     "Special program for Shavuot"
+                  ],
+                  "7093457":[
+                     "moreh lechaim",
+                     "Documentary series on teachers that fell in wars and hostile acts"
+                  ],
+                  "7067780":[
+                     "shoah ve'kolnoa",
+                     "Program on cinema and the Holocaust"
+                  ],
+                  "7063542":[
+                     "chozer im tshuva le'pesach",
+                     "The meaning of Passover "
                   ]
                },
                "sched_code_map":{
@@ -2719,6 +2819,39 @@
                   ],
                   "2155424":[
                      "Israel"
+                  ],
+                  "2161118":[
+                     "Japan"
+                  ],
+                  "1939353":[
+                     "Tsom Gedalia"
+                  ],
+                  "1896568":[
+                     "Tisha B'Av"
+                  ],
+                  "1867733":[
+                     "Ta'anit Ester"
+                  ],
+                  "1996898":[
+                     "David Ben-Gurion"
+                  ],
+                  "1933603":[
+                     "Kerem Hateimanim"
+                  ],
+                  "1933606":[
+                     "Be'er Ganim"
+                  ],
+                  "1933609":[
+                     "Hadera"
+                  ],
+                  "1933611":[
+                     "Neve Daniel"
+                  ],
+                  "1933614":[
+                     "Neve Sha'anan"
+                  ],
+                  "1933615":[
+                     "Safed (Tsfat)"
                   ]
                }
             }

--- a/data/data.json
+++ b/data/data.json
@@ -1316,7 +1316,7 @@
                      "Without Borders - Note: GeoBlocked"
                   ],
                   "7119627":[
-                     "Hagaltznikim - Note: GeoBlocked",
+                     "Hagaltznikim",
                      "A series about young people that became broadcasters in the IDF radio"
                   ],
                   "7120575":[


### PR DESCRIPTION
- Updated 6 pcodes and 1 mcode with GeoBlocked notices, Examples pcodes: 7065744 and 7120563
- 25 new pcodes were added  - e.g. choma shel tikva, mikdash me'at, yom shel tzom, yom yerushalaim, tekes chaylim mitztainim
- Added 11 new scodes, example scodes under mikdash me'at and yom shel tzom