### PR TITLE
Temporary ch10 fix

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -425,6 +425,7 @@
                "ShortDescriptionLine2":"See http://www.nana10.co.il",
                "Poster":"ch10.png",
                "StreamUrls":[
+		  "http://nana10-hdl-uk.ctedgecdn.net/Nana10-Live/amlst:hd_,1000,1500,1800,/chunklist_b1000000.m3u8",
                   "http://nana10-hdl-uk.ctedgecdn.net/Nana10-Live/amlst:hd_,1000,1500,1800,/playlist.m3u8",
                   "http://nana10-hdl-il.ctedgecdn.net/Nana10-Live/amlst:hd_,1000,1500,1800,/playlist.m3u8",
                   "http://nana10live-lh.akamaihd.net/i/Mob01_0@70462/index_1_av-p.m3u8?sd=10&rebase=on"


### PR DESCRIPTION
3 rates are listed in `http://nana10-hdl-uk.ctedgecdn.net/Nana10-Live/amlst:hd_,1000,1500,1800,/playlist.m3u8`

```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-STREAM-INF:BANDWIDTH=1000000
chunklist_b1000000.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=1500000
chunklist_b1500000.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=1800000
chunklist_b1800000.m3u8
```

but only the first one works.  Assuming this is a temporary problem