### PR TITLE
Rearrange backup news_co streams

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -424,9 +424,9 @@
                "Poster":"news_co.png",
                "StreamUrls":[
                   "http://ch2live-i.akamaihd.net/hls/live/252343/252343/playlist.m3u8",
-                  "http://keshethlslive-lh.akamaihd.net/i/c2n_1@195269/master.m3u8",
                   "http://besttv1.aoslive.it.best-tv.com/hls-live/reshet-neveilan01/_definst_/live/stream_profile3.m3u8",
-                  "http://besttv1.aoslive.it.best-tv.com/hls-live/reshet-neveilan01/_definst_/live/stream_profile1.m3u8"
+                  "http://besttv1.aoslive.it.best-tv.com/hls-live/reshet-neveilan01/_definst_/live/stream_profile1.m3u8",
+                  "http://keshethlslive-lh.akamaihd.net/i/c2n_1@195269/master.m3u8"
                ],
                "StreamFormat":"hls",
                "Live":true


### PR DESCRIPTION
Move to end the backup stream that seems to have a fixed image (aka "slide") over the past day